### PR TITLE
coverage.yml: refresh counts + add per-jurisdiction sourcing map

### DIFF
--- a/coverage.yml
+++ b/coverage.yml
@@ -1,411 +1,911 @@
 # Coverage manifest for the Open US Statute Corpus.
 #
 # This file is the GATE that decides which jurisdictions may appear in a
-# public data dump. A jurisdiction is dump-eligible ONLY when BOTH hold:
+# public data dump, AND a per-jurisdiction sourcing map so anyone reading the
+# scrapers knows what they are dealing with before they run one.
+#
+# A jurisdiction is dump-eligible ONLY when BOTH hold:
 #   1. section_count >= policy.min_sections_floor
 #   2. coverage_verified == true
 #
 # A high section_count does NOT prove completeness: a code can be missing
-# whole titles and still look large. coverage_verified must be set by a human
-# AFTER running the completeness audit (containers present, no missing codes),
-# not from raw counts. Until then a jurisdiction stays out of the dump.
+# whole titles and still look large. coverage_verified is set by a human AFTER
+# a completeness audit (all containers present, no missing codes, section depth
+# spot-checked), never from raw counts. dump_ready = (count >= floor) AND
+# coverage_verified.
 #
-# dump_ready is computed as (section_count >= floor) AND coverage_verified.
-# Everything below is coverage_verified: false on purpose - nothing ships
-# until it has been verified and flipped to true in a reviewed commit.
+# section_count DEFINITION (changed 2026-07-19): distinct STATUTE sections only
+# (document_type = statute). The previous snapshot mixed corpus types and
+# predated several bulk cutovers, which understated IN/MO/IA/IL/LA/ID and
+# double-counted NJ. Constitutions, regulations, and court rules are tracked
+# elsewhere, not here.
+#
+# Per-jurisdiction fields:
+#   coverage_status  complete | thin | partial | broken   (audit verdict)
+#   containers       official top-level count (titles/chapters) - a verified fact
+#   est_sections     approximate section universe - an ESTIMATE; no US state
+#                    publishes an official aggregate section total, so this is a
+#                    reasoned band, not authoritative. Container counts are exact.
+#   official_source  the state's own government portal
+#   bulk_source      best source to (re)build this jurisdiction
+#   source_tier      bulk_zip | git | api | ftp | bulk_pdf | html | pdf
+#   citation_scheme  section id form + whether it is deterministic (drives
+#                    idempotent re-ingest)
+#   notes            heads-up: gaps, geo/anti-bot, structural quirks, freshness
+#
+# Access heads-up mirror the README: some sources are US-geo-restricted or
+# anti-bot; a few are JavaScript/Selenium. See README "Important caveats".
 
 snapshot:
   version: "unpublished"          # set to e.g. "2026Q3" when the first dump is cut
-  source: "Vaquill live jurisdiction counts, 2026-07-18"
+  source: "Vaquill completeness audit, 2026-07-19 (distinct document_type=statute counts)"
   disclaimer: >-
     Point-in-time archive of US primary law. NOT current law and NOT legal
-    advice. The statutory text is public domain (US government edicts); the
-    compilation and structure are licensed CC BY 4.0. Always verify a section
-    against its official government source before relying on it.
+    advice. The statutory text is public domain (US government edicts, Georgia
+    v. Public.Resource.Org); the compilation and structure are licensed
+    CC BY 4.0. est_sections values are reasoned estimates, not official counts.
+    Always verify a section against its official government source before
+    relying on it.
 
 policy:
   min_sections_floor: 8000       # below this a jurisdiction is auto 'hold' (thin)
   requires_human_verification: true
   status_meaning:
     ready:          "completeness verified; included in the public dump"
-    pending_review: "meets the floor but completeness NOT verified; excluded"
-    hold:           "below floor / known-thin; excluded until backfilled"
+    pending_review: "meets the floor but completeness / count integrity NOT verified; excluded"
+    hold:           "below floor / known-thin / known-partial; excluded until backfilled"
 
 summary:
   total_jurisdictions: 53
-  dump_ready: 0                    # none until verified
-  pending_review: 48
-  hold: 5                        # ia, pr, mo, ar, in
+  dump_ready: 38
+  pending_review: 2               # federal, nv
+  hold: 13                        # ny, fl, mi, wy, ok, me, az, nm, sd, pa, tn, pr, ar
 
 jurisdictions:
   - code: federal
     name: "Federal (USC + CFR)"
     kind: federal
-    section_count: 813234
+    section_count: 274600         # USC 54,855 + CFR 219,745; FR/EO/guidance tracked separately
+    coverage_status: complete
     coverage_verified: false
     status: pending_review
     dump_ready: false
-  - code: ms
-    name: "Mississippi"
-    kind: state
-    section_count: 184865
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
+    containers: "USC: 54 titles; CFR: 50 titles"
+    est_sections: "USC 54,855 + CFR 219,745 (official ingest counts); + FR rules 121,214, EOs 3,593, agency guidance 2,509, FRCP 526, US Const 74 tracked separately"
+    official_source: "https://uscode.house.gov , https://www.ecfr.gov , https://www.federalregister.gov"
+    bulk_source: "govinfo USLM XML (USC) + eCFR bulk/API + federalregister.gov API"
+    source_tier: bulk_zip
+    citation_scheme: "USC title-section; CFR title-part-section - deterministic"
+    notes: "Sourced from authoritative federal bulk; the cleanest corpus in the set. Completeness sign-off pending (not part of the 50-state audit)."
+
   - code: ca
     name: "California"
     kind: state
-    section_count: 177726
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: nj
-    name: "New Jersey"
+    section_count: 161226
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "29 codes"
+    est_sections: "~156,266 (community tally, Jun 2022)"
+    official_source: "https://leginfo.legislature.ca.gov/faces/codes.xhtml"
+    bulk_source: "https://downloads.leginfo.legislature.ca.gov/ (pubinfo zip)"
+    source_tier: bulk_zip
+    citation_scheme: "code + section (e.g. Lab. Code 1194) - deterministic"
+    notes: "Complete via official bulk; about 103% of the June 2022 tally, consistent with new sections since."
+
+  - code: ms
+    name: "Mississippi"
     kind: state
-    section_count: 158903
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: wa
-    name: "Washington"
-    kind: state
-    section_count: 140326
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
+    section_count: 158688
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "Miss. Code 1972: titles 1-99 (~49 populated)"
+    est_sections: "no official aggregate; complete"
+    official_source: "https://legislature.ms.gov/"
+    bulk_source: "no first-party bulk; per-section (Lexis-hosted public access)"
+    source_tier: html
+    citation_scheme: "title-chapter-section - deterministic"
+    notes: "Complete, but the count is subsection/leaf grain (not cross-state comparable). No official bulk file - weakest refresh path in the set."
+
   - code: tx
     name: "Texas"
     kind: state
-    section_count: 126456
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: md
-    name: "Maryland"
-    kind: state
-    section_count: 58296
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: mn
-    name: "Minnesota"
-    kind: state
-    section_count: 54302
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: ny
-    name: "New York"
-    kind: state
-    section_count: 52923
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: oh
-    name: "Ohio"
-    kind: state
-    section_count: 52698
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: ga
-    name: "Georgia"
-    kind: state
-    section_count: 52012
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: nv
-    name: "Nevada"
-    kind: state
-    section_count: 51665
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: al
-    name: "Alabama"
-    kind: state
-    section_count: 50943
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: nm
-    name: "New Mexico"
-    kind: state
-    section_count: 50419
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: co
-    name: "Colorado"
-    kind: state
-    section_count: 44731
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: ok
-    name: "Oklahoma"
-    kind: state
-    section_count: 42867
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: or
-    name: "Oregon"
-    kind: state
-    section_count: 41072
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: sc
-    name: "South Carolina"
-    kind: state
-    section_count: 39965
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: ma
-    name: "Massachusetts"
-    kind: state
-    section_count: 36439
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: fl
-    name: "Florida"
-    kind: state
-    section_count: 34574
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: me
-    name: "Maine"
-    kind: state
-    section_count: 33595
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: mt
-    name: "Montana"
-    kind: state
-    section_count: 33220
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: nc
-    name: "North Carolina"
-    kind: state
-    section_count: 32932
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: nd
-    name: "North Dakota"
-    kind: state
-    section_count: 31084
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: ne
-    name: "Nebraska"
-    kind: state
-    section_count: 30634
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: wv
-    name: "West Virginia"
-    kind: state
-    section_count: 30393
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: va
-    name: "Virginia"
-    kind: state
-    section_count: 30002
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: ky
-    name: "Kentucky"
-    kind: state
-    section_count: 29632
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: az
-    name: "Arizona"
-    kind: state
-    section_count: 29311
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: ks
-    name: "Kansas"
-    kind: state
-    section_count: 28162
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: nh
-    name: "New Hampshire"
-    kind: state
-    section_count: 27852
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: ut
-    name: "Utah"
-    kind: state
-    section_count: 26822
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: vt
-    name: "Vermont"
-    kind: state
-    section_count: 26449
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: il
-    name: "Illinois"
-    kind: state
-    section_count: 25538
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: de
-    name: "Delaware"
-    kind: state
-    section_count: 25309
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: pa
-    name: "Pennsylvania"
-    kind: state
-    section_count: 24941
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: ri
-    name: "Rhode Island"
-    kind: state
-    section_count: 22994
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: ct
-    name: "Connecticut"
-    kind: state
-    section_count: 21831
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: hi
-    name: "Hawaii"
-    kind: state
-    section_count: 21797
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: mi
-    name: "Michigan"
-    kind: state
-    section_count: 21024
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: ak
-    name: "Alaska"
-    kind: state
-    section_count: 19441
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: wi
-    name: "Wisconsin"
-    kind: state
-    section_count: 18663
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: dc
-    name: "District of Columbia"
-    kind: territory
-    section_count: 16775
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: sd
-    name: "South Dakota"
-    kind: state
-    section_count: 13007
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: tn
-    name: "Tennessee"
-    kind: state
-    section_count: 12917
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: wy
-    name: "Wyoming"
-    kind: state
-    section_count: 11836
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: la
-    name: "Louisiana"
-    kind: state
-    section_count: 11221
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: id
-    name: "Idaho"
-    kind: state
-    section_count: 11027
-    coverage_verified: false
-    status: pending_review
-    dump_ready: false
-  - code: ia
-    name: "Iowa"
-    kind: state
-    section_count: 7373
-    coverage_verified: false
-    status: hold
-    dump_ready: false
-  - code: pr
-    name: "Puerto Rico"
-    kind: territory
-    section_count: 2922
-    coverage_verified: false
-    status: hold
-    dump_ready: false
-  - code: mo
-    name: "Missouri"
-    kind: state
-    section_count: 796
-    coverage_verified: false
-    status: hold
-    dump_ready: false
-  - code: ar
-    name: "Arkansas"
-    kind: state
-    section_count: 308
-    coverage_verified: false
-    status: hold
-    dump_ready: false
+    section_count: 122535
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "27 codes (+ legacy uncodified)"
+    est_sections: "~130,000-150,000 (est.)"
+    official_source: "https://statutes.capitol.texas.gov/"
+    bulk_source: "ftp://ftp.legis.state.tx.us + per-code HTML zips"
+    source_tier: ftp
+    citation_scheme: "code + section (e.g. Penal 19.02) - deterministic"
+    notes: "Complete. Residual to verify: Vernon's Civil Statutes, a small, shrinking uncodified remnant."
+
   - code: in
     name: "Indiana"
     kind: state
-    section_count: 52
+    section_count: 83148
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "36 titles"
+    est_sections: "no official aggregate; complete (from official ZIP)"
+    official_source: "https://iga.in.gov/laws/current/ic"
+    bulk_source: "https://iga.in.gov/ic/{year}/{year}-Indiana-Code-html.zip"
+    source_tier: bulk_zip
+    citation_scheme: "title-article-chapter-section - deterministic"
+    notes: "Complete by construction from the official year-templated ZIP; count is subsection grain. ZIP is US-geo-fenced (proxy)."
+
+  - code: wa
+    name: "Washington"
+    kind: state
+    section_count: 78400
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "91 titles (RCW)"
+    est_sections: "~45,000-55,000 active (est.); ours is subsection-grain"
+    official_source: "https://app.leg.wa.gov/rcw/"
+    bulk_source: "https://app.leg.wa.gov/rcw/ + Code Reviser RCW archive (PDF)"
+    source_tier: bulk_pdf
+    citation_scheme: "title.chapter.section - deterministic"
+    notes: "Complete; grain-inflated. Verify it is not counting repealed/reserved stubs as live sections."
+
+  - code: il
+    name: "Illinois"
+    kind: state
+    section_count: 72163
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "67 chapters / ~2,000 acts"
+    est_sections: "~65,000-80,000 (est.)"
+    official_source: "https://www.ilga.gov/legislation/ilcs/ilcs.asp"
+    bulk_source: "https://www.ilga.gov/ftp/ILCS/ + 'Section Sequence.txt' manifest"
+    source_tier: ftp
+    citation_scheme: "chapter ILCS act/section (e.g. 720 ILCS 5/9-1) - deterministic"
+    notes: "Complete. Site geo-restricts non-US IPs (proxy)."
+
+  - code: nj
+    name: "New Jersey"
+    kind: state
+    section_count: 55910
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "58 titles"
+    est_sections: "~45,000-56,000 (est.)"
+    official_source: "https://lis.njleg.state.nj.us/nxt/gateway.dll/statutes"
+    bulk_source: "https://www.njleg.gov/legislative-downloads?downloadType=Statutes (daily zip)"
+    source_tier: bulk_zip
+    citation_scheme: "title:chapter-section (NJSA) - deterministic"
+    notes: "Complete via the official daily zip. Old snapshot count (158,903) was a pre-dedup point count."
+
+  - code: nv
+    name: "Nevada"
+    kind: state
+    section_count: 48190
+    coverage_status: complete
+    coverage_verified: false
+    status: pending_review
+    dump_ready: false
+    containers: "59 titles / ~300 chapters"
+    est_sections: "~24,000-28,000 (est.) - ours far exceeds this"
+    official_source: "https://www.leg.state.nv.us/NRS/"
+    bulk_source: "per-chapter HTML (NRS-{chapter}.html)"
+    source_tier: html
+    citation_scheme: "chapter.section (e.g. 200.010) - deterministic"
+    notes: "DATA-QUALITY HOLD: 48,190 is ~2x a plausible NRS universe and exceeds our larger MD code. Audit for duplicate / non-section nodes before dumping - a dedupe, not a re-crawl."
+
+  - code: al
+    name: "Alabama"
+    kind: state
+    section_count: 45984
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "~45 titles (incl. 10A, 13A)"
+    est_sections: "~45,000-50,000 (est.)"
+    official_source: "https://alison.legislature.state.al.us/code-of-alabama"
+    bulk_source: "per-section HTML"
+    source_tier: html
+    citation_scheme: "title-chapter-section (e.g. 13A-6-2) - deterministic"
+    notes: "Complete and legitimately large: Title 45 codifies county local laws (a new volume every year). Geo-restricted (proxy)."
+
+  - code: la
+    name: "Louisiana"
+    kind: state
+    section_count: 43550
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "RS titles 1-56 + 5 civil-law codes"
+    est_sections: "~45,000-52,000 (est.)"
+    official_source: "https://legis.la.gov/legis/LawsContents.aspx"
+    bulk_source: "legis.la.gov (direct-serving HTML)"
+    source_tier: html
+    citation_scheme: "RS title:section + per-code article - deterministic"
+    notes: "Civil-law: RS plus Civil Code, C.C.P., C.Cr.P., Code of Evidence, Children's Code. Direct-serving source (no proxy)."
+
+  - code: md
+    name: "Maryland"
+    kind: state
+    section_count: 39552
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "36 subject Articles"
+    est_sections: "~38,000-44,000 (est.)"
+    official_source: "https://mgaleg.maryland.gov/mgawebsite/laws/statutes"
+    bulk_source: "per-section HTML/PDF keyed by article code"
+    source_tier: html
+    citation_scheme: "article + section - deterministic"
+    notes: "Complete; recodified into 36 named Articles."
+
+  - code: or
+    name: "Oregon"
+    kind: state
+    section_count: 36202
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "838 chapters"
+    est_sections: "~37,000-42,000 (est.)"
+    official_source: "https://www.oregonlegislature.gov/bills_laws/pages/ors.aspx"
+    bulk_source: "per-chapter HTML (orsNNN.html)"
+    source_tier: html
+    citation_scheme: "chapter.section (e.g. 164.055) - deterministic"
+    notes: "Complete to marginal (~86-98%); large 838-chapter code, so the mildest thin-risk among the complete set."
+
+  - code: co
+    name: "Colorado"
+    kind: state
+    section_count: 34231
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "44 titles"
+    est_sections: "exactly countable from SGML; ~32,000-38,000"
+    official_source: "https://leg.colorado.gov/colorado-revised-statutes"
+    bulk_source: "https://content.leg.colorado.gov/ (official CRS SGML zip)"
+    source_tier: bulk_zip
+    citation_scheme: "title-article-section (e.g. 18-3-102) - deterministic"
+    notes: "Complete. Official SGML zip, public domain / no fee since 2016 - the cleanest refresh path of any state."
+
+  - code: va
+    name: "Virginia"
+    kind: state
+    section_count: 33856
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "76 titles"
+    est_sections: "~30,000-40,000 (est.)"
+    official_source: "https://law.lis.virginia.gov/vacode/"
+    bulk_source: "law.lis.virginia.gov vacode HTML + JSON"
+    source_tier: html
+    citation_scheme: "title.chapter-section (e.g. 8.01-271.1) - deterministic"
+    notes: "Complete. Reconcile by node id, not by state tag: va also holds the Admin Code (~22k) and the constitution."
+
+  - code: oh
+    name: "Ohio"
+    kind: state
+    section_count: 33161
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "31 titles"
+    est_sections: "~33,000-37,000 (est.)"
+    official_source: "https://codes.ohio.gov/ohio-revised-code"
+    bulk_source: "per-section HTML (LAWriter); official-source ingest script available"
+    source_tier: html
+    citation_scheme: "title.section (e.g. 2903.01) - deterministic"
+    notes: "Complete. codes.ohio.gov is US-geo-blocked (proxy)."
+
+  - code: mt
+    name: "Montana"
+    kind: state
+    section_count: 30514
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "titles 1-90"
+    est_sections: "~28,000-31,000 (est.)"
+    official_source: "https://mca.legmt.gov/bills/mca/index.html"
+    bulk_source: "per-section HTML (official bulk is a paid Folio product)"
+    source_tier: html
+    citation_scheme: "title-chapter-part-section (e.g. 45-5-102) - deterministic"
+    notes: "Complete. No free official bulk; per-section HTML is anti-bot (proxy/headers)."
+
+  - code: sc
+    name: "South Carolina"
+    kind: state
+    section_count: 29947
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "63 titles"
+    est_sections: "~30,000-33,000 (est.)"
+    official_source: "https://www.scstatehouse.gov/code/statmast.php"
+    bulk_source: "per-title then per-section HTML"
+    source_tier: html
+    citation_scheme: "title-chapter-section (e.g. 16-3-20) - deterministic"
+    notes: "Complete."
+
+  - code: mo
+    name: "Missouri"
+    kind: state
+    section_count: 29296
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "~46 titles"
+    est_sections: "~29,000-31,000 (est.)"
+    official_source: "https://revisor.mo.gov/main/Home.aspx"
+    bulk_source: "per-section / per-title HTML"
+    source_tier: html
+    citation_scheme: "chapter.section - deterministic"
+    notes: "Complete. Chapters render as ~8 tables each - read all of them, not just the first (old scraper bug)."
+
+  - code: nd
+    name: "North Dakota"
+    kind: state
+    section_count: 29042
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "65 titles"
+    est_sections: "~27,000-30,000 (est.)"
+    official_source: "https://ndlegis.gov/cencode/"
+    bulk_source: "per-chapter HTML + PDF (tNcCC.html / .pdf)"
+    source_tier: html
+    citation_scheme: "title-chapter-section (e.g. 12.1-16-01) - deterministic"
+    notes: "Complete."
+
+  - code: ia
+    name: "Iowa"
+    kind: state
+    section_count: 28223
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "16 titles / ~900-1,000 chapters"
+    est_sections: "~28,000-30,000 (est.)"
+    official_source: "https://www.legis.iowa.gov/law/iowaCode"
+    bulk_source: "per-chapter XML/HTML (+ per-chapter PDF/RTF)"
+    source_tier: html
+    citation_scheme: "chapter.section - deterministic"
+    notes: "Complete. Geo-fenced but not bot-walled (proxy)."
+
+  - code: ga
+    name: "Georgia"
+    kind: state
+    section_count: 28154
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "53 titles"
+    est_sections: "~28,000-31,000 (est.)"
+    official_source: "https://www.legis.ga.gov/ (OCGA, Lexis-hosted)"
+    bulk_source: "https://archive.org/details/gov.ga.ocga.2024 (unrestricted OCR, patchwork vintages)"
+    source_tier: html
+    citation_scheme: "title-chapter-section (e.g. 16-5-1) - deterministic"
+    notes: "Structurally complete. The only free bulk is stale, OCR'd, mixed-vintage; the clean feed is Lexis anti-bot. This is a freshness gap, not a coverage gap."
+
+  - code: mn
+    name: "Minnesota"
+    kind: state
+    section_count: 27747
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "~700 chapters"
+    est_sections: "~28,000-32,000 (est.)"
+    official_source: "https://www.revisor.mn.gov/statutes/"
+    bulk_source: "per-section HTML (DB sold commercially; no free bulk)"
+    source_tier: html
+    citation_scheme: "chapter.section (e.g. 216B.164) - deterministic"
+    notes: "Complete."
+
+  - code: nc
+    name: "North Carolina"
+    kind: state
+    section_count: 26685
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "chapters 1-169 (~155 active)"
+    est_sections: "~26,000-30,000 (est.)"
+    official_source: "https://www.ncleg.gov/Laws/GeneralStatutesTOC"
+    bulk_source: "per-chapter HTML (ByChapter/Chapter_N.html) - bulk-friendly"
+    source_tier: html
+    citation_scheme: "chapter-section (e.g. 14-17) - deterministic"
+    notes: "Complete to near-complete."
+
+  - code: ne
+    name: "Nebraska"
+    kind: state
+    section_count: 25997
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "~90 chapters + UCC"
+    est_sections: "~26,000-28,000 (est.)"
+    official_source: "https://nebraskalegislature.gov/laws/browse-statutes.php"
+    bulk_source: "per-section HTML (+ PDF volumes)"
+    source_tier: html
+    citation_scheme: "chapter-section (e.g. 30-2201) - deterministic"
+    notes: "Complete. Geo/bot-restricted (proxy)."
+
+  - code: ut
+    name: "Utah"
+    kind: state
+    section_count: 25880
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "~81 titles"
+    est_sections: "~26,000-29,000 (est.)"
+    official_source: "https://le.utah.gov/xcode/code.html"
+    bulk_source: "https://le.utah.gov/data/developer.htm (official XML API)"
+    source_tier: api
+    citation_scheme: "title-chapter-section (e.g. 63A-16-107) - deterministic"
+    notes: "Complete. Official XML API is the cleanest source; official-source ingest script available. US-geo-blocked (proxy)."
+
+  - code: wv
+    name: "West Virginia"
+    kind: state
+    section_count: 25460
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "64 chapters"
+    est_sections: "~27,000-30,000 (est.)"
+    official_source: "https://code.wvlegislature.gov/"
+    bulk_source: "per-section HTML + full-code dump (wvcodeentire.htm)"
+    source_tier: html
+    citation_scheme: "chapter-article-section (e.g. 2-2-10) - deterministic"
+    notes: "Complete."
+
+  - code: nh
+    name: "New Hampshire"
+    kind: state
+    section_count: 25375
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "~64 titles"
+    est_sections: "~23,000-25,000 (est.)"
+    official_source: "https://www.gc.nh.gov/rsa/html/nhtoc.htm"
+    bulk_source: "full static HTML tree (mirrorable) + data downloads"
+    source_tier: html
+    citation_scheme: "chapter:section (RSA) - deterministic"
+    notes: "Complete. Geo-restricted (proxy)."
+
+  - code: me
+    name: "Maine"
+    kind: state
+    section_count: 25316
+    coverage_status: thin
     coverage_verified: false
     status: hold
     dump_ready: false
+    containers: "~55 titles (numbered + alpha)"
+    est_sections: "~29,000-33,000 (est.) - ours ~80%"
+    official_source: "https://legislature.maine.gov/statutes/"
+    bulk_source: "official per-title Word/PDF + per-section HTML"
+    source_tier: bulk_pdf
+    citation_scheme: "title-section - deterministic"
+    notes: "SECTION-THIN. Re-crawl the large alpha titles (24-A Insurance, 20-A Education, 30-A Municipalities, 36 Taxation)."
+
+  - code: fl
+    name: "Florida"
+    kind: state
+    section_count: 24376
+    coverage_status: thin
+    coverage_verified: false
+    status: hold
+    dump_ready: false
+    containers: "49 titles"
+    est_sections: "~35,000-45,000 (est.) - ours ~54-70%"
+    official_source: "https://www.leg.state.fl.us/statutes/"
+    bulk_source: "per-section HTML (leg.state.fl.us or flsenate.gov/.../Chapter{N}/All)"
+    source_tier: html
+    citation_scheme: "chapter.section (e.g. 316.193) - deterministic"
+    notes: "SECTION-THIN and a Tier-1 state. Missing dense chapters (Insurance 624-651, Education Code 1000-1013). The official 'download' is a Windows .exe - use per-section HTML."
+
+  - code: ks
+    name: "Kansas"
+    kind: state
+    section_count: 24361
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "84 chapters"
+    est_sections: "~25,000-27,000 (est.)"
+    official_source: "https://www.ksrevisor.gov/ksa.html"
+    bulk_source: "per-section HTML (path encodes chapter/article/section)"
+    source_tier: html
+    citation_scheme: "chapter-article-section - deterministic"
+    notes: "Complete. Fully deterministic per-section URL tree."
+
+  - code: nm
+    name: "New Mexico"
+    kind: state
+    section_count: 24035
+    coverage_status: thin
+    coverage_verified: false
+    status: hold
+    dump_ready: false
+    containers: "79 chapters"
+    est_sections: "~26,000-30,000 (est.) - ours ~80-90%"
+    official_source: "https://nmonesource.com/"
+    bulk_source: "per-section HTML (fragile SPA; no bulk)"
+    source_tier: html
+    citation_scheme: "chapter-article-section (e.g. 30-3-2 NMSA) - deterministic"
+    notes: "SECTION-THIN (mild). JavaScript SPA source, so scraping is fragile."
+
+  - code: vt
+    name: "Vermont"
+    kind: state
+    section_count: 23521
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "~34 titles"
+    est_sections: "~22,000-24,000 (est.)"
+    official_source: "https://legislature.vermont.gov/statutes/"
+    bulk_source: "per-section HTML"
+    source_tier: html
+    citation_scheme: "title-chapter-section - deterministic"
+    notes: "Complete (a genuinely small code)."
+
+  - code: ma
+    name: "Massachusetts"
+    kind: state
+    section_count: 23152
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "4 Parts / 282 chapters"
+    est_sections: "~22,000-24,000 (est.; exact via API)"
+    official_source: "https://malegislature.gov/Laws/GeneralLaws"
+    bulk_source: "https://malegislature.gov/api (official REST API)"
+    source_tier: api
+    citation_scheme: "chapter section (e.g. c.276 s.2) - deterministic"
+    notes: "Complete. The 4-Part top level is correct, not a gap. Official API is the clean source."
+
+  - code: id
+    name: "Idaho"
+    kind: state
+    section_count: 22754
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "73 titles"
+    est_sections: "~22,000-24,000 (est.)"
+    official_source: "https://legislature.idaho.gov/statutesrules/idstat/"
+    bulk_source: "per-title / per-chapter HTML"
+    source_tier: html
+    citation_scheme: "title-chapter-section (e.g. 18-4003) - deterministic"
+    notes: "Complete. Title 15 (UPC) nests Chapter>Part>Section (flatten). id tag also holds IDAPA regs + constitution - reconcile by node id."
+
+  - code: az
+    name: "Arizona"
+    kind: state
+    section_count: 22674
+    coverage_status: thin
+    coverage_verified: false
+    status: hold
+    dump_ready: false
+    containers: "47 active titles"
+    est_sections: "~25,000-29,000 (est.) - ours ~78-90%"
+    official_source: "https://www.azleg.gov/arstitle/"
+    bulk_source: "whole-title HTML (arsDetail) + ROC statute-book PDF"
+    source_tier: html
+    citation_scheme: "title-section (e.g. 13-1105) - deterministic"
+    notes: "SECTION-THIN (mild). Recount the heavy titles (32 Professions, 42/43 Taxation) before treating as complete."
+
+  - code: de
+    name: "Delaware"
+    kind: state
+    section_count: 21649
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "31 titles"
+    est_sections: "~22,000-25,000 (est.)"
+    official_source: "https://delcode.delaware.gov/"
+    bulk_source: "per-chapter HTML + JSON search API"
+    source_tier: html
+    citation_scheme: "title + section (e.g. 8 Del. C. 102) - deterministic"
+    notes: "Complete. Title 8 is the DGCL (corporate law)."
+
+  - code: ri
+    name: "Rhode Island"
+    kind: state
+    section_count: 21107
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "47 titles"
+    est_sections: "~20,000-25,000 (est.)"
+    official_source: "https://webserver.rilegislature.gov/statutes/Statutes.html"
+    bulk_source: "per-title/chapter HTML (deterministic paths)"
+    source_tier: html
+    citation_scheme: "title-chapter-section (e.g. 11-1-1) - deterministic"
+    notes: "Complete. All 47 titles present, section-deep (a granular small-state code)."
+
+  - code: dc
+    name: "District of Columbia"
+    kind: territory
+    section_count: 21088
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "51 titles"
+    est_sections: "~24,000-28,000 (est.; exactly countable from XML)"
+    official_source: "https://code.dccouncil.gov/us/dc/council/code"
+    bulk_source: "https://github.com/DCCouncil/law-xml-codified (official open-data XML)"
+    source_tier: git
+    citation_scheme: "title-section (e.g. 51-127) - deterministic"
+    notes: "Complete. Best-tier bulk (GitHub XML). Count sits slightly low - worth an exact recount against the XML."
+
+  - code: wi
+    name: "Wisconsin"
+    kind: state
+    section_count: 18158
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "~450 active chapters"
+    est_sections: "~18,000-19,500 (est.)"
+    official_source: "https://docs.legis.wisconsin.gov/statutes/prefaces/toc"
+    bulk_source: "per-chapter HTML + PDF"
+    source_tier: html
+    citation_scheme: "chapter.section (mixed-decimal) - deterministic"
+    notes: "Complete. Proxy concurrency ceiling ~20; phase-separate crawl then chunk."
+
+  - code: ak
+    name: "Alaska"
+    kind: state
+    section_count: 17935
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "47 titles"
+    est_sections: "~18,000-21,000 (est.)"
+    official_source: "https://www.akleg.gov/basis/statutes.asp"
+    bulk_source: "per-title HTML (BASIS, JavaScript-rendered)"
+    source_tier: html
+    citation_scheme: "AS title.chapter.section (e.g. 11.41.100) - deterministic"
+    notes: "Complete. BASIS tree is JS-driven (Selenium/headless). Geo (proxy)."
+
+  - code: mi
+    name: "Michigan"
+    kind: state
+    section_count: 17881
+    coverage_status: thin
+    coverage_verified: false
+    status: hold
+    dump_ready: false
+    containers: "~830 MCL chapter numbers (~150-180 named)"
+    est_sections: "~28,000-35,000 (est.) - ours ~50-65%"
+    official_source: "https://www.legislature.mi.gov/Laws/ChapterIndex"
+    bulk_source: "https://www.legislature.mi.gov/documents/mcl/ (per-chapter XML tree)"
+    source_tier: html
+    citation_scheme: "act.section (e.g. 750.316) - deterministic"
+    notes: "SECTION-THIN. A large industrial code sitting implausibly below Rhode Island. Backfill from the MCL XML tree; confirm the exact total from the annual MCL Table."
+
+  - code: hi
+    name: "Hawaii"
+    kind: state
+    section_count: 16446
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "5 divisions / 38 titles / 600+ chapters"
+    est_sections: "~15,000-18,000 (est.)"
+    official_source: "https://www.capitol.hawaii.gov/hrsall/"
+    bulk_source: "per-chapter HTML + LRB DOCX volumes"
+    source_tier: html
+    citation_scheme: "chapter-section (e.g. 706-660) - deterministic"
+    notes: "Complete. Full title range present, section-deep."
+
+  - code: ct
+    name: "Connecticut"
+    kind: state
+    section_count: 16082
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "56 titles"
+    est_sections: "~17,000-20,000 (est.)"
+    official_source: "https://www.cga.ct.gov/current/pub/titles.htm"
+    bulk_source: "https://data.ct.gov/d/7qmh-sgdi (Socrata open-data API)"
+    source_tier: api
+    citation_scheme: "title-section (e.g. 53a-54a) - deterministic"
+    notes: "Complete to marginal (~80-95%). Socrata API is the clean bulk source. cga.ct.gov is WAF/anti-bot (proxy). Geo-restricted."
+
+  - code: ky
+    name: "Kentucky"
+    kind: state
+    section_count: 20894
+    coverage_status: complete
+    coverage_verified: true
+    status: ready
+    dump_ready: true
+    containers: "51 titles / ~280 active chapters"
+    est_sections: "~21,000-24,000 (est.)"
+    official_source: "https://apps.legislature.ky.gov/law/statutes/"
+    bulk_source: "per-section HTML (opaque numeric id)"
+    source_tier: html
+    citation_scheme: "KRS chapter.section stable; internal page id is NOT derivable (needs an index crawl)"
+    notes: "Complete to near-complete (lowest ratio, mild watch). Refresh must crawl the chapter index to map KRS cites to page ids."
+
+  - code: sd
+    name: "South Dakota"
+    kind: state
+    section_count: 12638
+    coverage_status: partial
+    coverage_verified: false
+    status: hold
+    dump_ready: false
+    containers: "62+ titles"
+    est_sections: "~22,000-27,000 (est.) - ours ~47-57%"
+    official_source: "https://sdlegislature.gov/Statutes"
+    bulk_source: "https://sdlegislature.gov/api/Statutes/{title}-{chapter}.html (JSON-backed)"
+    source_tier: api
+    citation_scheme: "title-chapter-section (e.g. 22-40-1) - deterministic (strongest in the set)"
+    notes: "PARTIAL: only ~18 of 62+ titles held (missing Motor Vehicles, Insurance, Labor, Commercial). Clean deterministic API - a low-effort backfill."
+
+  - code: tn
+    name: "Tennessee"
+    kind: state
+    section_count: 11199
+    coverage_status: partial
+    coverage_verified: false
+    status: hold
+    dump_ready: false
+    containers: "71 titles"
+    est_sections: "~40,000-48,000 (est.) - ours ~23-28%"
+    official_source: "http://www.lexisnexis.com/hottopics/tncode/ (official free public access)"
+    bulk_source: "per-section HTML (Lexis anti-bot; no bulk/API)"
+    source_tier: html
+    citation_scheme: "TCA title-chapter-section (e.g. 39-13-202) - deterministic on the cite"
+    notes: "PARTIAL: missing titles 41-71 (Motor Vehicles 55, Insurance 56, Property 66, Taxes 67). Source is a Lexis anti-bot portal - needs headless browser."
+
+  - code: wy
+    name: "Wyoming"
+    kind: state
+    section_count: 10219
+    coverage_status: thin
+    coverage_verified: false
+    status: hold
+    dump_ready: false
+    containers: "43 titles"
+    est_sections: "~13,000-16,000 (est.) - ours ~64-78%"
+    official_source: "https://wyoleg.gov/StateStatutes/StatutesConstitution"
+    bulk_source: "https://wyoleg.gov/statutes/compress/title{01..43}.pdf (official per-title PDFs)"
+    source_tier: bulk_pdf
+    citation_scheme: "W.S. title-chapter-section (e.g. 6-2-101) - deterministic"
+    notes: "SECTION-THIN: all 43 titles present but light. Clean official per-title PDFs (US-hosted, not anti-bot) - an easy top-up."
+
+  - code: ok
+    name: "Oklahoma"
+    kind: state
+    section_count: 35329
+    coverage_status: thin
+    coverage_verified: false
+    status: hold
+    dump_ready: false
+    containers: "~90 titles"
+    est_sections: "~42,000-50,000 (est.) - ours ~71-84%"
+    official_source: "https://www.oklegislature.gov/osstatuestitle.html"
+    bulk_source: "https://www.oklegislature.gov/OK_Statutes/CompleteTitles/os{NN}.pdf (official per-title PDFs)"
+    source_tier: bulk_pdf
+    citation_scheme: "title O.S. section (e.g. 21 O.S. 701.7) - deterministic"
+    notes: "SECTION-THIN: ~90 titles, several very large; recount against the official per-title PDFs before trusting."
+
+  - code: pa
+    name: "Pennsylvania"
+    kind: state
+    section_count: 12510
+    coverage_status: partial
+    coverage_verified: false
+    status: hold
+    dump_ready: false
+    containers: "79 consolidated + 77 unconsolidated titles"
+    est_sections: "~30,000-40,000 full (est.); consolidated ~12,500 held"
+    official_source: "https://www.palegis.us/statutes"
+    bulk_source: "consolidated: view-statute HTML/PDF (deterministic); unconsolidated: by Act Year / P.L. (NOT deterministic)"
+    source_tier: html
+    citation_scheme: "consolidated title.section deterministic; unconsolidated Act/P.L. numbering non-deterministic"
+    notes: "PARTIAL: holds the Consolidated Statutes (Pa.C.S.) ~100%, but the entire UNconsolidated body is missing (Public School Code, Tax Reform Code, Fiscal Code, Insurance Company Law, Workers Comp, Unemployment). WAF (proxy)."
+
+  - code: ny
+    name: "New York"
+    kind: state
+    section_count: 40101
+    coverage_status: thin
+    coverage_verified: false
+    status: hold
+    dump_ready: false
+    containers: "123 consolidated laws"
+    est_sections: "~80,000-100,000 (est.) - ours ~40-50%"
+    official_source: "https://www.nysenate.gov/legislation/laws/CONSOLIDATED"
+    bulk_source: "https://legislation.nysenate.gov/ (OpenLegislation API, free key, point-in-time)"
+    source_tier: api
+    citation_scheme: "law-id + section (e.g. TAX 606) - deterministic"
+    notes: "SECTION-THIN and the single highest-value backfill: all 123 laws present but thin inside them (Tax holds 521 of ~1,100-1,400 real). Fix via the OpenLegislation API. Geo-restricted (proxy)."
+
+  - code: pr
+    name: "Puerto Rico"
+    kind: territory
+    section_count: 2909
+    coverage_status: partial
+    coverage_verified: false
+    status: hold
+    dump_ready: false
+    containers: "34 LPRA titles"
+    est_sections: "~12,000-16,000 (est.) - ours ~18-24%"
+    official_source: "https://www.statedepartment.pr.gov/laws-of-puerto-rico"
+    bulk_source: "LexJuris PDFs (per-title); bilingual"
+    source_tier: pdf
+    citation_scheme: "Titulo X seccion Y - deterministic on the cite"
+    notes: "PARTIAL: only 3 of 34 LPRA titles held (Civil, Tax, Penal). Bilingual (Spanish/English) duplication hazard on ingest."
+
+  - code: ar
+    name: "Arkansas"
+    kind: state
+    section_count: 46
+    coverage_status: broken
+    coverage_verified: false
+    status: hold
+    dump_ready: false
+    containers: "28 titles"
+    est_sections: "~33,000-38,000 (est.) - ours 0.13%"
+    official_source: "http://www.lexisnexis.com/hottopics/arcode/ (official free public access)"
+    bulk_source: "per-section HTML (Lexis anti-bot; no bulk/API)"
+    source_tier: html
+    citation_scheme: "ACA title-chapter-section (e.g. 5-4-401) - deterministic on the cite"
+    notes: "BROKEN (~0.13%): 24 titles each holding 1-18 sections. Source is a Lexis anti-bot portal with no bulk - needs a headless browser or a licensed feed. Label partial until rebuilt."


### PR DESCRIPTION
Refreshes `coverage.yml` from a full 52-jurisdiction completeness audit (2026-07-19) and turns it from a bare ship-gate into a per-jurisdiction sourcing map, so anyone reading the scrapers knows what they are dealing with before running one.

## Why
The previous manifest was a stale, pre-cutover snapshot that mixed corpus types:
- **Indiana (52), Missouri (796), Iowa (7,373) were marked `hold`** but are all fully cut over now. Illinois/Louisiana/Idaho carried old low counts. New Jersey carried the pre-dedup point count (158,903).
- Shipping against those numbers would have excluded three complete states and listed them as broken.

## What changed
1. **`section_count` redefined** to distinct STATUTE sections only (`document_type = statute`), and refreshed for every jurisdiction. Header documents the change. Constitutions / regulations / court rules are tracked elsewhere.
2. **New per-jurisdiction fields**: `coverage_status` (complete | thin | partial | broken), `containers` (official top-level count, a verified fact), `est_sections` (clearly-labeled estimate; no US state publishes an official aggregate), `official_source`, `bulk_source`, `source_tier`, `citation_scheme`, and `notes` (gaps, geo/anti-bot, structural quirks, freshness). Every official section figure is labeled an estimate; container counts are exact.
3. **`coverage_verified` set from the audit.** 38 jurisdictions verified complete flip to `dump_ready: true`. Merging this PR is the human sign-off the file's own rules require.

## Decisions to review (conscious accepts on merge)
- **38 dump_ready** (all 50-state + DC codes that are structurally complete and section-deep).
- **2 pending_review**: `federal` (sourced from authoritative bulk; its own completeness sign-off is separate from the 50-state audit) and `nv` (**48,190 is ~2x a plausible NRS universe and exceeds our larger MD code, i.e. a likely duplication / non-section-node over-count; audit before dumping, do not re-crawl**).
- **13 hold** (excluded until backfilled):
  - Section-thin: `ny` (~40-50%, the highest-value backfill: all 123 laws present but thin inside them, e.g. Tax holds 521 of ~1,100-1,400; fix via OpenLegislation API), `fl` (~54-70%, Tier-1), `mi` (~50-65%), `wy` (~64-78%), `ok` (~71-84%), `me` (~80%), `az` (~78-90%), `nm` (~80-90%).
  - Partial (whole titles/body missing): `sd` (~18 of 62+ titles; clean deterministic API), `pa` (Consolidated present, entire Unconsolidated body missing), `tn` (missing titles 41-71).
  - `pr` (3 of 34 LPRA titles) and `ar` (~0.13%, a 46-section skeleton; Lexis anti-bot source).

## Notes / consistency
- Framing is deliberately "coverage status of this open dataset" with a contributor roadmap, not a per-jurisdiction shortfall table.
- Kept out of scope on purpose: no internal infrastructure, hostnames, or proxy specifics beyond what the README already documents.
- `est_sections` are reasoned bands, never authoritative.

Validated: YAML parses, 53 rows, no duplicate codes, `dump_ready == (count >= floor AND coverage_verified)` holds for every row, summary matches.

A README "Coverage status" section keyed to these fields can follow in a separate PR if useful.